### PR TITLE
Add support of curly braces for attributes in markup

### DIFF
--- a/src/Tokenizer.spec.ts
+++ b/src/Tokenizer.spec.ts
@@ -266,11 +266,11 @@ describe('Tokenizer', () => {
             curlyBracesInAttributes: true
         }, logger);
 
-        const input = '<div on:click={() => console.log(\'}\' + "}" + `}`)}></div>';
+        const input = '<div on:click={() => console.log(\'}\' + "} \\"}" + `}`)}></div>';
         const expectedOutput = [
             "onopentagname: 'div'",
             "onattribname: 'on:click'",
-            "onattribdata: '() => console.log(\'}\' + \"}\" + `}`)'",
+            "onattribdata: '() => console.log('}' + \"} \\\"}\" + `}`)'",
             'onattribend',
             'onopentagend',
             "onclosetag: 'div'",
@@ -317,7 +317,7 @@ describe('Tokenizer', () => {
         const input = '<div styles={{ width: 100, height: 200 }}></div>';
         const expectedOutput = [
             "onopentagname: 'div'",
-            "onattribname: 'on:click'",
+            "onattribname: 'styles'",
             "onattribdata: '{ width: 100, height: 200 }'",
             'onattribend',
             'onopentagend',

--- a/src/Tokenizer.spec.ts
+++ b/src/Tokenizer.spec.ts
@@ -164,4 +164,169 @@ describe('Tokenizer', () => {
         tokenizer.reset();
         logger.log = [];
     });
+
+    test('should support attributes', () => {
+        const logger = new CallbackLogger();
+        const tokenizer = new Tokenizer({
+            xmlMode: false,
+            decodeEntities: false
+        }, logger);
+
+        const input = '<div width=100></div>';
+        const expectedOutput = [
+            "onopentagname: 'div'",
+            "onattribname: 'width'",
+            "onattribdata: '100'",
+            'onattribend',
+            'onopentagend',
+            "onclosetag: 'div'",
+            'onend'
+        ];
+
+        tokenizer.write(input);
+        tokenizer.end();
+        expect(logger.log).toEqual(expectedOutput);
+    });
+
+    test('should support double quoted attributes', () => {
+        const logger = new CallbackLogger();
+        const tokenizer = new Tokenizer({
+            xmlMode: false,
+            decodeEntities: false
+        }, logger);
+
+        const input = '<div title="title attribute text"></div>';
+        const expectedOutput = [
+            "onopentagname: 'div'",
+            "onattribname: 'title'",
+            "onattribdata: 'title attribute text'",
+            'onattribend',
+            'onopentagend',
+            "onclosetag: 'div'",
+            'onend'
+        ];
+
+        tokenizer.write(input);
+        tokenizer.end();
+        expect(logger.log).toEqual(expectedOutput);
+    });
+
+    test('should support single quoted attributes', () => {
+        const logger = new CallbackLogger();
+        const tokenizer = new Tokenizer({
+            xmlMode: false,
+            decodeEntities: false
+        }, logger);
+
+        const input = '<div title=\'title attribute text\'></div>';
+        const expectedOutput = [
+            "onopentagname: 'div'",
+            "onattribname: 'title'",
+            "onattribdata: 'title attribute text'",
+            'onattribend',
+            'onopentagend',
+            "onclosetag: 'div'",
+            'onend'
+        ];
+
+        tokenizer.write(input);
+        tokenizer.end();
+        expect(logger.log).toEqual(expectedOutput);
+    });
+
+    test('should support curly braced attributes', () => {
+        const logger = new CallbackLogger();
+        const tokenizer = new Tokenizer({
+            xmlMode: false,
+            decodeEntities: false,
+            curlyBracesInAttributes: true
+        }, logger);
+
+        const input = '<div on:click={() => handleClick()}></div>';
+        const expectedOutput = [
+            "onopentagname: 'div'",
+            "onattribname: 'on:click'",
+            "onattribdata: '() => handleClick()'",
+            'onattribend',
+            'onopentagend',
+            "onclosetag: 'div'",
+            'onend'
+        ];
+
+        tokenizer.write(input);
+        tokenizer.end();
+        expect(logger.log).toEqual(expectedOutput);
+    });
+
+    test('should support curly braced attributes with escaping in JS strings', () => {
+        const logger = new CallbackLogger();
+        const tokenizer = new Tokenizer({
+            xmlMode: false,
+            decodeEntities: false,
+            curlyBracesInAttributes: true
+        }, logger);
+
+        const input = '<div on:click={() => console.log(\'}\' + "}" + `}`)}></div>';
+        const expectedOutput = [
+            "onopentagname: 'div'",
+            "onattribname: 'on:click'",
+            "onattribdata: '() => console.log(\'}\' + \"}\" + `}`)'",
+            'onattribend',
+            'onopentagend',
+            "onclosetag: 'div'",
+            'onend'
+        ];
+
+        tokenizer.write(input);
+        tokenizer.end();
+        expect(logger.log).toEqual(expectedOutput);
+    });
+
+    test('should support curly braced attributes with escaping by inline JS comments', () => {
+        const logger = new CallbackLogger();
+        const tokenizer = new Tokenizer({
+            xmlMode: false,
+            decodeEntities: false,
+            curlyBracesInAttributes: true
+        }, logger);
+
+        const input = '<div on:click={() => console.log("c") /* } */}></div>';
+        const expectedOutput = [
+            "onopentagname: 'div'",
+            "onattribname: 'on:click'",
+            "onattribdata: '() => console.log(\"c\") /* } */'",
+            'onattribend',
+            'onopentagend',
+            "onclosetag: 'div'",
+            'onend'
+        ];
+
+        tokenizer.write(input);
+        tokenizer.end();
+        expect(logger.log).toEqual(expectedOutput);
+    });
+
+    test('should support curly braced attributes with nesting scopes', () => {
+        const logger = new CallbackLogger();
+        const tokenizer = new Tokenizer({
+            xmlMode: false,
+            decodeEntities: false,
+            curlyBracesInAttributes: true
+        }, logger);
+
+        const input = '<div styles={{ width: 100, height: 200 }}></div>';
+        const expectedOutput = [
+            "onopentagname: 'div'",
+            "onattribname: 'on:click'",
+            "onattribdata: '{ width: 100, height: 200 }'",
+            'onattribend',
+            'onopentagend',
+            "onclosetag: 'div'",
+            'onend'
+        ];
+
+        tokenizer.write(input);
+        tokenizer.end();
+        expect(logger.log).toEqual(expectedOutput);
+    });
 });

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -434,7 +434,7 @@ export default class Tokenizer {
         } else if (c === "'") {
             this._state = State.InAttributeValueSq;
             this._sectionStart = this._index + 1;
-        } else if (c === '{') {
+        } else if (this._curlyBracesInAttributes && c === '{') {
             this._state = State.InAttributeValueCurly;
             this._sectionStart = this._index + 1;
             this._jsStateStack = [];

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -252,7 +252,7 @@ export default class Tokenizer {
     _decodeEntities: boolean;
 
     constructor(
-        options: { xmlMode?: boolean; decodeEntities?: boolean } | null,
+        options: { xmlMode?: boolean; decodeEntities?: boolean, curlyBracesInAttributes?: boolean } | null,
         cbs: Callbacks
     ) {
         this._cbs = cbs;


### PR DESCRIPTION
This fix introduce a support of curly braces for attribute values in HTML markup, that can be useful to handle Svelte likes markups
```
<button on:click={() => handleClick()}>Button</button>
```

Original issue: #545
Related issue: https://github.com/alexprey/sveltedoc-parser/issues/28